### PR TITLE
Add support for custom formatting of progress

### DIFF
--- a/README
+++ b/README
@@ -78,6 +78,7 @@ Parameters
 -  ``zfill`` bar zero fill symbol (default: -)
 -  ``decimals`` positive number of decimals in percent complete
    (default: 1)
+-  ``formatter`` a function that formats the count and goal, useful for handling large numbers like file sizes
 
 Any Questions? Report a Bug? Enhancements?
 ------------------------------------------

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ manager.progress_2.stop('stop progress 2')
 * `fill` bar fill symbol (default: █)
 * `zfill` bar zero fill symbol (default: -)
 * `decimals` positive number of decimals in percent complete  (default: 1)
+* `formatter` a function that formats the count and goal, useful for handling large numbers like file sizes
 
 ## Any Questions? Report a Bug? Enhancements?
 

--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,7 @@ Parameters
 -  ``zfill`` bar zero fill symbol (default: -)
 -  ``decimals`` positive number of decimals in percent complete
    (default: 1)
+-  ``formatter`` a function that formats the count and goal, useful for handling large numbers like file sizes
 
 Any Questions? Report a Bug? Enhancements?
 ------------------------------------------

--- a/cli_progressbar/progressbar.py
+++ b/cli_progressbar/progressbar.py
@@ -10,20 +10,17 @@ class Progress:
     def __init__(self, goal: int = -1):
         self.goal = goal
         self.status = ''
-        self.showing_status = ''
-        self.longest_status = 0
         self.bar_len = 60
         self.fill = '█'
         self.zfill = '-'
         self.decimals = 1
         self.formatter = lambda x: x
+        self.last_len = 0
 
     def set_status(self, status: str):
         if status == self.status:
             return
         self.status = status
-        self.longest_status = max(len(status), self.longest_status)
-        self.showing_status = status + ' ' * (self.longest_status - len(status))
 
     def update(self, count: int, status: str = ''):
         self.set_status(status)
@@ -34,8 +31,12 @@ class Progress:
         bar = self.fill * filled_len + self.zfill * (self.bar_len - filled_len)
 
         text = '[%s] %s%s | %s/%s' % (bar, percents, '%', self.formatter(count), self.formatter(self.goal))
-        if self.showing_status:
-            text += ' | %s' % self.showing_status
+        if self.status:
+            text += ' | %s' % self.status
+
+        padding = ' ' * (self.last_len - len(text))
+        self.last_len = len(text)
+        text += padding
 
         pos = getattr(self, 'pos', 0)
         self.move_to(pos)

--- a/cli_progressbar/progressbar.py
+++ b/cli_progressbar/progressbar.py
@@ -16,6 +16,7 @@ class Progress:
         self.fill = '█'
         self.zfill = '-'
         self.decimals = 1
+        self.formatter = lambda x: x
 
     def set_status(self, status: str):
         if status == self.status:
@@ -32,7 +33,7 @@ class Progress:
         percents = round(100.0 * count / float(self.goal), self.decimals)
         bar = self.fill * filled_len + self.zfill * (self.bar_len - filled_len)
 
-        text = '[%s] %s%s | %s/%s' % (bar, percents, '%', count, self.goal)
+        text = '[%s] %s%s | %s/%s' % (bar, percents, '%', self.formatter(count), self.formatter(self.goal))
         if self.showing_status:
             text += ' | %s' % self.showing_status
 


### PR DESCRIPTION
The default display of count/goal is not great when the progressbar tracks a large number like size of a downloaded file.

This attribute allows setting a function that can process the value before it is printed.